### PR TITLE
Fix wrong method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $packagist = new \Spatie\Packagist\Packagist($client);
 
 ### Get all packages by a specific vendor
 ``` php
-$packagist->getVendorPackages('spatie');
+$packagist->getPackagesByVendor('spatie');
 ```
 
 ### Find a package by it's name


### PR DESCRIPTION
Super small PR that just fixes the wrong method name in the documentation/readme.