### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:
-  - phpunit --coverage-text --coverage-clover=coverage.clover
+  - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - php vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "guzzlehttp/guzzle":"^6.2.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*"
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-4": {

--- a/tests/PackagistTest.php
+++ b/tests/PackagistTest.php
@@ -4,9 +4,10 @@ namespace Spatie\Packagist\Test;
 
 use Exception;
 use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
 use Spatie\Packagist\Packagist;
 
-class PackagistTest extends \PHPUnit_Framework_TestCase
+class PackagistTest extends TestCase
 {
     /** @var \Spatie\Packagist\Packagist */
     protected $packagist;


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

Just needed to bump PHPUnit version to [`4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), to keep compatibility.

I've also updated `Travis CI` to use `PHPUnit` installed version, not the global onw.

I didn't update to `PHPUnit 5` 'cause this package still supports `PHP 5.5`.