### PR TITLE
Add ability to search by both package and type

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ $packagist->findPackageByName('spatie/laravel-backup');
 $packagist->getPackagesByType('symfony-bundle');
 ```
 
+### Get all packages by name and type
+``` php
+$packagist->getPackagesByName('monolog', 'symfony-bundle')
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/src/Packagist.php
+++ b/src/Packagist.php
@@ -61,7 +61,7 @@ class Packagist
     {
         $query = ['q' => $name];
 
-        if($type != '') {
+        if ($type != '') {
             $query['type'] = $type;
         }
 

--- a/src/Packagist.php
+++ b/src/Packagist.php
@@ -57,9 +57,15 @@ class Packagist
      *
      * @return array
      */
-    public function getPackagesByName($name)
+    public function getPackagesByName($name, $type = '')
     {
-        return $this->makeRequest('/search.json', ['q' => $name]);
+        $query = ['q' => $name];
+
+        if($type != '') {
+            $query['type'] = $type;
+        }
+
+        return $this->makeRequest('/search.json', $query);
     }
 
     /**

--- a/tests/PackagistTest.php
+++ b/tests/PackagistTest.php
@@ -105,4 +105,17 @@ class PackagistTest extends TestCase
 
         $this->packagist->getPackagesByType('');
     }
+
+     /** @test */
+    public function it_can_get_packages_by_name_and_type()
+    {
+        $fullPackageName = 'symfony/monolog-bundle';
+        $type = 'symfony-bundle';
+
+        $result = $this->packagist->getPackagesByName($fullPackageName, $type);
+
+        $this->assertArrayHasKey('results', $result);
+
+        $this->assertSame($fullPackageName, $result['results'][0]['name']);
+    }
 }

--- a/tests/PackagistTest.php
+++ b/tests/PackagistTest.php
@@ -106,7 +106,7 @@ class PackagistTest extends TestCase
         $this->packagist->getPackagesByType('');
     }
 
-     /** @test */
+    /** @test */
     public function it_can_get_packages_by_name_and_type()
     {
         $fullPackageName = 'symfony/monolog-bundle';


### PR DESCRIPTION
Adds a parameter to getPackagesByName to allow filtering the returned search results to a specific type of package.  Defaults to current functionality if parameter $type not specified.