### PR TITLE
Support Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php" : "^7.2",
         "ext-json": "*",
-        "guzzlehttp/guzzle":"^6.5"
+        "guzzlehttp/guzzle":"^6.5|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.0",

--- a/tests/Unit/PackagistClientTest.php
+++ b/tests/Unit/PackagistClientTest.php
@@ -170,7 +170,7 @@ class PackagistClientTest extends TestCase
     {
         $mock = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->addMethods(['get'])
+            ->onlyMethods(['get'])
             ->getMock();
 
         $mock->expects($this->once())


### PR DESCRIPTION
Adds support for Guzzle 7. The differences between Guzzle 6 and Guzzle 7 are minimal, so no actual code changes are necessary.

I changed `->addMethods(['get'])` to `->onlyMethods(['get'])` for the Guzzle Client mock, because Guzzle 7 actually has that method on the client instead of handling it through `__call()`. This prevents PHPUnit from emitting warnings like this:

> Trying to set mock method "get" with addMethods(), but it exists in class "GuzzleHttp\Client". Use onlyMethods() for methods that exist in the class.

PHPUnit would now emit the opposite warning when testing with Guzzle 6, but I assume this isn't a problem, since Guzzle 7 should always be installed when running tests.