### PR TITLE
Add PHP 8.1 Support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: spatie
 custom: https://spatie.be/open-source/support-us

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -8,12 +8,12 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v1
+                uses: actions/checkout@v2
 
             -   name: Fix style
                 uses: docker://oskarstark/php-cs-fixer-ga
                 with:
-                    args: --config=.php_cs --allow-risky=yes
+                    args: --config=.php-cs-fixer.dist.php --allow-risky=yes
 
             -   name: Extract branch name
                 shell: bash

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
                 os: [ubuntu-latest, windows-latest]
                 php: [8.1, 8.0, 7.4, 7.3, 7.2]
                 dependency-version: [prefer-lowest, prefer-stable]
-                phpunit: [^8.5,9.*]
+                phpunit: [^8.5, 9.*]
                 exclude:
                   - phpunit: ^8.5
                     php: 8.1
@@ -37,8 +37,8 @@ jobs:
 
             -   name: Install dependencies
                 run: |
-                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
-                    composer install phpunit/${{ matrix.phpunit }} --prefer-dist --no-interaction --no-suggest
+                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+                    composer require "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
 
             -   name: Execute tests
                 run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,17 +9,17 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [7.2, 7.3, 7.4, 8.0]
+                php: [8.1, 8.0, 7.4, 7.3, 7.2]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v1
+                uses: actions/checkout@v2
 
             -   name: Cache dependencies
-                uses: actions/cache@v1
+                uses: actions/cache@v2
                 with:
                     path: ~/.composer/cache/files
                     key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,11 @@ jobs:
                 os: [ubuntu-latest, windows-latest]
                 php: [8.1, 8.0, 7.4, 7.3, 7.2]
                 dependency-version: [prefer-lowest, prefer-stable]
-
+                phpunit: [^8.5,9.*]
+                exclude:
+                  - phpunit: ^8.5
+                    php: 8.1
+                    
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
@@ -32,7 +36,9 @@ jobs:
                     coverage: none
 
             -   name: Install dependencies
-                run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+                run: |
+                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+                    composer install phpunit/${{ matrix.phpunit }} --prefer-dist --no-interaction --no-suggest
 
             -   name: Execute tests
                 run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,12 +9,8 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [8.1, 8.0, 7.4, 7.3, 7.2]
+                php: [8.1, 8.0, 7.4, 7.3]
                 dependency-version: [prefer-lowest, prefer-stable]
-                phpunit: [^8.5, 9.*]
-                exclude:
-                  - phpunit: ^8.5
-                    php: 8.1
                     
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
@@ -36,9 +32,7 @@ jobs:
                     coverage: none
 
             -   name: Install dependencies
-                run: |
-                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
-                    composer require "phpunit/phpunit:${{ matrix.phpunit }}" --no-interaction --no-update
+                run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
             -   name: Execute tests
                 run: vendor/bin/phpunit

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,28 @@
+name: "Update Changelog"
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ build
 composer.lock
 docs
 vendor
-.php_cs.cache
+*.cache
 phpunit.xml

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -3,7 +3,6 @@
 $finder = Symfony\Component\Finder\Finder::create()
     ->notPath('bootstrap/*')
     ->notPath('storage/*')
-    ->notPath('storage/*')
     ->notPath('resources/view/mail/*')
     ->in([
         __DIR__ . '/src',
@@ -14,14 +13,14 @@ $finder = Symfony\Component\Finder\Finder::create()
     ->ignoreDotFiles(true)
     ->ignoreVCS(true);
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config)
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => ['sortAlgorithm' => 'alpha'],
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'no_unused_imports' => true,
         'not_operator_with_successor_space' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline' => true,
         'phpdoc_scalar' => true,
         'unary_operator_spaces' => true,
         'binary_operator_spaces' => true,

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.3|^8.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.5|^7.0"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5|^9.4"
+        "phpunit/phpunit": "^9.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
         }
     ],
     "require": {
-        "php" : "^7.2|^8.0",
+        "php": "^7.2|^8.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle":"^6.5|^7.0"
+        "guzzlehttp/guzzle": "^6.5|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5|^9.0"
+        "phpunit/phpunit": "^8.5|^9.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,25 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Spatie Unit Test Suite">
-            <directory>tests/Unit</directory>
-        </testsuite>
-        <testsuite name="Spatie Integration Test Suite">
-            <directory>tests/Integration</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+<phpunit 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    colors="true"
+    verbose="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Spatie Unit Test Suite">
+      <directory>tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Spatie Integration Test Suite">
+      <directory>tests/Integration</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>


### PR DESCRIPTION
This PR adds PHP 8.1 support to the run tests workflow.

Additionally, it:
- drops support for PHP 7.2 and `PHPUnit` 8.x
- bumps latest dependency versions in `composer.json` where possible
- updates `php-cs-fixer` workflow & config
- migrates `PHPUnit` schema to latest & added coverage reports to match other packages
- adds update changelog workflow
- minor package housekeeping

_This repository needs its primary branch renamed from `master` to `main`._